### PR TITLE
Fix git integration

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -45,6 +45,9 @@ otp_insert() {
 
 	[[ $force -eq 0 && -e $passfile ]] && yesno "An entry already exists for $path. Overwrite it?"
 
+	local passfile="$PREFIX/$path.gpg"
+	set_git "$passfile"
+
 	mkdir -p -v "$PREFIX/$(dirname "$path")"
 	set_gpg_recipients "$(dirname "$path")"
 

--- a/otp.bash
+++ b/otp.bash
@@ -45,7 +45,6 @@ otp_insert() {
 
 	[[ $force -eq 0 && -e $passfile ]] && yesno "An entry already exists for $path. Overwrite it?"
 
-	local passfile="$PREFIX/$path.gpg"
 	set_git "$passfile"
 
 	mkdir -p -v "$PREFIX/$(dirname "$path")"


### PR DESCRIPTION
On my system git_add_file() fails because the $INNER_GIT_DIR variable is not set. Therefore, git doesn't commit the OTP key. We can set $INNER_GIT_DIR by calling the set_git function, which is included in pass. Then git should commit the OTP key.