### PR TITLE
Generate default passname from URI label; remove url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,25 @@ More information may be found in the pass-otp(1) man page.
 
 ## Examples
 
-Insert a TOTP token:
-
-```
-$ pass otp insert otpauth://totp/totp-secret?secret=AAAAAAAAAAAAAAAA totp-secret
-```
-
-Have `pass-otp` prompt you for a token (avoids potential shell history leakage):
+Prompt for an OTP token, hiding input:
 
 ```
 $ pass otp insert totp-secret
+Enter otpauth:// URI for totp-secret:
+Retype otpauth:// URI for totp-secret:
+```
+
+Prompt for an OTP token, echoing input:
+
+```
+$ pass otp insert -e totp-secret
+Enter otpauth:// URI for totp-secret: otpauth://totp/totp-secret?secret=AAAAAAAAAAAAAAAA&issuer=totp-secret
 ```
 
 Pipe an `otpauth://` URI into a passfile:
 
 ```
-$ cat totp-uri.txt | pass otp insert totp-secret
+$ cat totp-secret.txt | pass otp insert totp-secret
 ```
 
 Use [zbar](http://zbar.sourceforge.net/) to decode a QR image into a passfile:
@@ -89,11 +92,18 @@ $ pass otp uri -q totp-secret
 
 ## Installation
 
+### From git
+
 ```
 git clone https://github.com/tadfisher/pass-otp
 cd pass-otp
 sudo make install
 ```
+
+### Arch Linux
+
+`pass-otp` is available in the
+[Arch User Repository](https://aur.archlinux.org/packages/pass-otp/).
 
 ## Requirements
 

--- a/pass-otp.1
+++ b/pass-otp.1
@@ -37,16 +37,17 @@ and then restore the clipboard after 45 (or \fIPASSWORD_STORE_CLIP_TIME\fP)
 seconds. This command is alternatively named \fBshow\fP.
 
 .TP
-\fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] [ \fIuri\fP ] \fIpass-name\fP
+\fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] [ \fIpass-name\fP ]
 
-Insert a new OTP secret specified by \fIuri\fP into the password store at
-\fIpass-name\fP. \fIuri\fP must be formatted according to the Key Uri Format;
+Prompt for and insert a new OTP secret into the password store at
+\fIpass-name\fP. The secret must be formatted according to the Key Uri Format;
 see the documentation at
 .UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
 .UE .
-If \fIuri\fP is not specified, it will be consumed from stdin; specify
-\fI--echo\fP or \fI-e\fP to show a visible prompt when running this command
-interactively. Prompt before overwriting an existing password, unless
+The URI is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
+when running this command interactively. If \fIpass-name\fP is not specified,
+convert the \fIissuer:accountname\fP URI label to a path in the form of
+\fIisser/accountname\fP. Prompt before overwriting an existing password, unless
 \fI--force\fP or \fI-f\fP is specified. This command is alternatively named
 \fBadd\fP.
 

--- a/test/code.t
+++ b/test/code.t
@@ -8,7 +8,7 @@ test_expect_success 'Generates TOTP code' '
   uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
 
   test_pass_init &&
-  "$PASS" otp insert "$uri" passfile &&
+  "$PASS" otp insert passfile <<< "$uri" &&
   code=$("$PASS" otp passfile) &&
   [[ ${#code} -eq 6 ]]
 '
@@ -18,7 +18,7 @@ test_expect_success 'Generates HOTP code and increments counter' '
   inc="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=11&issuer=Example"
 
   test_pass_init &&
-  "$PASS" otp insert "$uri" passfile &&
+  "$PASS" otp insert passfile <<< "$uri" &&
   code=$("$PASS" otp passfile) &&
   [[ ${#code} -eq 6 ]] &&
   [[ $("$PASS" otp uri passfile) == "$inc" ]]

--- a/test/insert.t
+++ b/test/insert.t
@@ -4,43 +4,6 @@ export test_description="Tests pass otp insert commands"
 
 . ./setup.sh
 
-test_expect_success 'Inserts a key URI' '
-  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
-
-  test_pass_init &&
-  "$PASS" otp insert "$uri" passfile &&
-  [[ $("$PASS" show passfile) == "$uri" ]]
-'
-
-test_expect_success 'Prompts before overwriting key URI' '
-  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
-  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
-
-  test_pass_init
-  "$PASS" otp insert "$uri1" passfile
-  expect <<EOD
-    spawn "$PASS" otp insert "$uri2" passfile
-    expect {
-      "An entry already exists" {
-        send "n\r"
-        exp_continue
-      }
-      eof
-    }
-EOD
-  [[ $("$PASS" show passfile) == "$uri1" ]]
-'
-
-test_expect_success 'Force overwrites key URI' '
-  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
-  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
-
-  test_pass_init &&
-  "$PASS" otp insert "$uri1" passfile &&
-  "$PASS" otp insert -f "$uri2" passfile &&
-  [[ $("$PASS" show passfile) == "$uri2" ]]
-'
-
 test_expect_success 'Reads non-terminal input' '
   uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
 
@@ -85,6 +48,68 @@ test_expect_success 'Reads terminal input in echo mode' '
     }
 EOD
   [[ $("$PASS" show passfile) == "$uri" ]]
+'
+
+test_expect_success 'Prompts before overwriting key URI' '
+  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
+  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
+
+  test_pass_init
+  "$PASS" otp insert passfile <<< "$uri1" || return 1
+  expect <<EOD
+    spawn "$PASS" otp insert -e passfile
+    expect {
+      "Enter" {
+        send "$uri2\r"
+        exp_continue
+      }
+      "An entry already exists" {
+        send "n\r"
+        exp_continue
+      }
+      eof
+    }
+EOD
+  [[ $("$PASS" show passfile) == "$uri1" ]]
+'
+
+test_expect_success 'Generates default pass-name from label' '
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init
+  "$PASS" otp insert <<< "$uri"
+  [[ $("$PASS" show "Example/alice@google.com") == "$uri" ]]
+'
+
+test_expect_success 'Prompts when inserting default pass-name from terminal' '
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init
+  expect <<EOD
+    spawn "$PASS" otp insert -e
+    expect {
+      "Enter" {
+        send "$uri\r"
+        exp_continue
+      }
+      "Insert into Example/alice@google.com?" {
+        send "y\r"
+        exp_continue
+      }
+      eof
+    }
+EOD
+  [[ $("$PASS" show "Example/alice@google.com") == "$uri" ]]
+'
+
+test_expect_success 'Force overwrites key URI' '
+  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
+  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
+
+  test_pass_init &&
+  "$PASS" otp insert passfile <<< "$uri1" &&
+  "$PASS" otp insert -f passfile <<< "$uri2" &&
+  [[ $("$PASS" show passfile) == "$uri2" ]]
 '
 
 test_done

--- a/test/uri.t
+++ b/test/uri.t
@@ -8,7 +8,7 @@ test_expect_success 'Shows key URI in single-line passfile' '
   uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
 
   test_pass_init &&
-  "$PASS" otp insert "$uri" passfile &&
+  "$PASS" otp insert passfile <<< "$uri" &&
   [[ $("$PASS" otp uri passfile) == "$uri" ]]
 '
 


### PR DESCRIPTION
Fix #18 
Fix #19 

If `pass-name` is not supplied, convert the `issuer:accountname` label to a path in the form `issuer/accountname`.

Remove the `[uri]` parameter, as it can result in history leakage.