### PR TITLE
Add cmd_otp_append for appending OTP secrets to existing passfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ sudo make install
 
 ## Requirements
 
-- `pass` 1.7.0 or later for extenstion support
+- `pass` 1.7.0 or later for extension support
 - `oathtool` for generating 2FA codes
 - `qrencode` for generating QR code images
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ Usage:
         Generate an OTP code and optionally put it on the clipboard.
         If put on the clipboard, it will be cleared in 45 seconds.
 
-    pass otp insert [--force,-f] [--echo,-e] [uri] pass-name
-        Insert a new OTP key URI. If one is not supplied, it will be read from
-        stdin. Optionally, echo the input. Prompt before overwriting existing
-        password unless forced.
+    pass otp insert [--force,-f] [--echo,-e] [pass-name]
+        Prompt for and insert a new OTP key URI. If pass-name is not supplied,
+        use the URI label. Optionally, echo the input. Prompt before overwriting
+        existing password unless forced. This command accepts input from stdin.
+
+    pass otp append [--force,-f] [--echo,-e] pass-name
+        Appends an OTP key URI to an existing password file. Optionally, echo
+        the input. Prompt before overwriting an existing URI unless forced. This
+        command accepts input from stdin.
 
     pass otp uri [--clip,-c] [--qrcode,-q] pass-name
         Display the key URI stored in pass-name. Optionally, put it on the

--- a/pass-otp.1
+++ b/pass-otp.1
@@ -52,6 +52,18 @@ convert the \fIissuer:accountname\fP URI label to a path in the form of
 \fBadd\fP.
 
 .TP
+\fBotp append\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \fIpass-name\fP
+
+Append an OTP secret to the password stored in \fIpass-name\fP, preserving any
+existing lines. The secret must be formatted according to the Key Uri Format;
+see the documentation at
+.UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
+.UE .
+The URI is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
+when running this command interactively. Prompt before overwriting an existing
+secret, unless \fI--force\fP or \fI-f\fP is specified.
+
+.TP
 \fBotp uri\fP [ \fI--clip\fP, \fI-c\fP | \fI--qrcode\fP, \fI-q\fP ] \fIpass-name\fP
 
 Print the key URI stored in \fIpass-name\fP to stdout. If \fI--clip\fP or
@@ -75,20 +87,13 @@ information about this format, see the documentation at
 .SH OPTIONS
 
 .TP
-\fB\-c\fP, \fB--clip\fP
-Put the OTP code in the clipboard.
-
-.TP
-\fB\-f\fP, \fB--force\fP
-Force update and do not wait for user instruction.
-
-.TP
-\fBhelp\fP, \fB\-h\fB, \-\-help\fR
+\fBhelp\fP, \fB\-h\fP, \fB\-\-help\fP
 Show usage message.
 
 .SH SEE ALSO
-.BR pass(1),
-
+.BR pass (1),
+.BR qrencode (1),
+.BR zbarimg (1)
 
 .SH AUTHORS
 .B pass-otp
@@ -96,7 +101,6 @@ was written by
 .MT tadfisher@gmail.com
 Tad Fisher
 .ME .
-
 
 .SH COPYING
 This program is free software: you can redistribute it and/or modify

--- a/test/append.t
+++ b/test/append.t
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+export test_description="Tests pass otp append commands"
+
+. ./setup.sh
+
+test_expect_success 'Reads non-terminal input' '
+  existing="foo bar baz"
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  "$PASS" otp append -e passfile <<< "$uri" &&
+  [[ $("$PASS" otp uri passfile) == "$uri" ]]
+'
+
+test_expect_success 'Reads terminal input in noecho mode' '
+  existing="foo bar baz"
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  { expect -d <<EOD
+    spawn "$PASS" otp append passfile
+    expect {
+      "Enter" {
+        send "$uri\r"
+        exp_continue
+      }
+      "Retype" {
+        send "$uri\r"
+        exp_continue
+      }
+      eof
+    }
+EOD
+  } &&
+  [[ $("$PASS" otp uri passfile) == "$uri" ]]
+'
+
+test_expect_success 'Reads terminal input in echo mode' '
+  existing="foo bar baz"
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  {
+    expect <<EOD
+      spawn "$PASS" otp append -e passfile
+      expect {
+        "Enter" {
+          send "$uri\r"
+          exp_continue
+        }
+        eof
+      }
+EOD
+  } &&
+  [[ $("$PASS" otp uri passfile) == "$uri" ]]
+'
+
+test_expect_success 'Prompts before overwriting key URI' '
+  existing="foo bar baz"
+  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
+  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  "$PASS" otp append -e passfile <<< "$uri1" &&
+  {
+    expect -d <<EOD
+      spawn "$PASS" otp append -e passfile
+      expect {
+        "Enter" {
+          send "$uri2\r"
+          exp_continue
+        }
+        "An OTP secret already exists" {
+          send "n\r"
+          exp_continue
+        }
+        eof
+      }
+EOD
+  } &&
+  [[ $("$PASS" otp uri passfile) == "$uri1" ]]
+'
+
+test_expect_success 'Force overwrites key URI' '
+  existing="foo bar baz"
+  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
+  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  "$PASS" otp append -e passfile <<< "$uri1" &&
+  "$PASS" otp append -ef passfile <<< "$uri2" &&
+  [[ $("$PASS" otp uri passfile) == "$uri2" ]]
+'
+
+test_expect_success 'Preserves multiline contents' '
+  uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"
+  uri2="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Bar"
+
+  read -r -d "" existing <<EOF
+foo bar baz
+zab rab oof
+$uri1
+baz bar foo
+EOF
+
+  read -r -d "" expected <<EOF
+foo bar baz
+zab rab oof
+$uri2
+baz bar foo
+EOF
+
+  test_pass_init &&
+  "$PASS" insert -mf passfile <<< "$existing" &&
+  "$PASS" otp append -ef passfile <<< "$uri2" &&
+  [[ $("$PASS" show passfile) == "$expected" ]]
+'
+
+test_done

--- a/test/code.t
+++ b/test/code.t
@@ -24,4 +24,28 @@ test_expect_success 'Generates HOTP code and increments counter' '
   [[ $("$PASS" otp uri passfile) == "$inc" ]]
 '
 
+test_expect_success 'HOTP counter increments and preserves multiline contents' '
+  uri="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=10&issuer=Example"
+  inc="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=11&issuer=Example"
+
+  read -r -d "" existing <<EOF
+foo bar baz
+zab rab oof
+$uri1
+baz bar foo
+EOF
+
+  read -r -d "" expected <<EOF
+foo bar baz
+zab rab oof
+$uri2
+baz bar foo
+EOF
+
+  test_pass_init &&
+  "$PASS" insert -mf passfile <<< "$existing" &&
+  "$PASS" otp code passfile &&
+  [[ $("$PASS" show passfile) == "$expected" ]]
+'
+
 test_done


### PR DESCRIPTION
Fix #10 

Add `pass otp append`, which non-destructively appends an OTP secret or replaces an existing one in a passfile.