### PR TITLE
otp.bash: Normalize otp_type value to lowercase

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -31,7 +31,7 @@ otp_parse_uri() {
   [[ "$uri" =~ $pattern ]] || die "Cannot parse OTP key URI: $uri"
 
   otp_uri=${BASH_REMATCH[0]}
-  otp_type=${BASH_REMATCH[1]}
+  otp_type=${BASH_REMATCH[1],,}
   otp_label=${BASH_REMATCH[3]}
 
   otp_accountname=${BASH_REMATCH[6]}


### PR DESCRIPTION
oathtool is a bit sensitive about the case of the sha type. This
simply forces the value to be lowercase if the oath site gives a
url in upper case.

Should close #37 

Signed-off-by: Mark Stenglein <mark@stengle.in>