### PR TITLE
Add secret option

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -194,6 +194,7 @@ cmd_otp_insert() {
   fi
 
   if [[ $from_secret -eq 1 ]]; then
+    ([[ -z "$issuer" ]] || [[ -z "$account" ]]) && die "Missing issuer or account"
     otp_read_secret "$prompt" $echo "$issuer" "$account"
   else
     otp_read_uri "$prompt" $echo
@@ -243,6 +244,7 @@ cmd_otp_append() {
   [[ -n "$existing" ]] && yesno "An OTP secret already exists for $path. Overwrite it?"
 
   if [[ $from_secret -eq 1 ]]; then
+    ([[ -z "$issuer" ]] || [[ -z "$account" ]]) && die "Missing issuer or account"
     otp_read_secret "$prompt" $echo "$issuer" "$account"
   else
     otp_read_uri "$prompt" $echo

--- a/otp.bash
+++ b/otp.bash
@@ -109,13 +109,13 @@ otp_read_secret() {
 
   if [[ -t 0 ]]; then
     if [[ $echo -eq 0 ]]; then
-      read -r -p "Enter Secret Parameter for $prompt: " -s secret || exit 1
+      read -r -p "Enter secret for $prompt: " -s secret || exit 1
       echo
-      read -r -p "Retype Secret Parameter for $prompt: " -s secret_again || exit 1
+      read -r -p "Retype secret for $prompt: " -s secret_again || exit 1
       echo
-      [[ "$secret" == "$secret_again" ]] || die "Error: the entered Secrets do not match."
+      [[ "$secret" == "$secret_again" ]] || die "Error: the entered secrets do not match."
     else
-        read -r -p "Enter Secret Parameter for $prompt: " -e secret
+        read -r -p "Enter secret for $prompt: " -e secret
     fi
   else
       read -r secret
@@ -147,15 +147,30 @@ Usage:
         Generate an OTP code and optionally put it on the clipboard.
         If put on the clipboard, it will be cleared in $CLIP_TIME seconds.
 
-    $PROGRAM otp insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i Issuer] [--account,-a Account] [pass-name]
-        Prompt for and insert a new OTP key URI. If pass-name is not supplied,
-        use the URI label. Optionally, echo the input. Prompt before overwriting
-        existing password unless forced. This command accepts input from stdin.
+    $PROGRAM otp insert [--force,-f] [--echo,-e]
+            [[--secret, -s] [--issuer,-i issuer] [--account,-a account]]
+            [pass-name]
+        Prompt for and insert a new OTP key.
 
-    $PROGRAM otp append [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i Issuer] [--account,-a Account] pass-name
-        Appends an OTP key URI to an existing password file. Optionally, echo
-        the input. Prompt before overwriting an existing URI unless forced. This
-        command accepts input from stdin.
+        If 'secret' is specified, prompt for the OTP secret, assuming SHA1
+        algorithm, 30-second period, and 6 OTP digits; one of 'issuer' or
+        'account' is also required. Otherwise, prompt for a key URI; if
+        'pass-name' is not supplied, use the URI label.
+
+        Optionally, echo the input. Prompt before overwriting existing URI
+        unless forced. This command accepts input from stdin.
+
+    $PROGRAM otp append [--force,-f] [--echo,-e]
+            [[--secret, -s] [--issuer,-i issuer] [--account,-a account]]
+            pass-name
+        Appends an OTP key URI to an existing password file.
+
+        If 'secret' is specified, prompt for the OTP secret, assuming SHA1
+        algorithm, 30-second period, and 6 OTP digits; one of 'issuer' or
+        'account' is also required. Otherwise, prompt for a key URI.
+
+        Optionally, echo the input. Prompt before overwriting an existing URI
+        unless forced. This command accepts input from stdin.
 
     $PROGRAM otp uri [--clip,-c] [--qrcode,-q] pass-name
         Display the key URI stored in pass-name. Optionally, put it on the
@@ -183,7 +198,7 @@ cmd_otp_insert() {
     --) shift; break ;;
   esac done
 
-  [[ $err -ne 0 ]] && die "Usage: $PROGRAM $COMMAND insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i Issuer] [--account,-a Account] [pass-name]"
+  [[ $err -ne 0 ]] && die "Usage: $PROGRAM $COMMAND insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] [pass-name]"
 
   local prompt path uri
   if [[ $# -eq 1 ]]; then
@@ -226,7 +241,7 @@ cmd_otp_append() {
     --) shift; break ;;
   esac done
 
-  [[ $err -ne 0 || $# -ne 1 ]] && die "Usage: $PROGRAM $COMMAND append [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i Issuer] [--account,-a Account] pass-name"
+  [[ $err -ne 0 || $# -ne 1 ]] && die "Usage: $PROGRAM $COMMAND append [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] pass-name"
 
   local prompt uri
   local path="${1%/}"

--- a/pass-otp.1
+++ b/pass-otp.1
@@ -37,28 +37,46 @@ and then restore the clipboard after 45 (or \fIPASSWORD_STORE_CLIP_TIME\fP)
 seconds. This command is alternatively named \fBshow\fP.
 
 .TP
-\fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] [ \fIpass-name\fP ]
+\fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \
+[ [ \fI--secret\fP, \fI-s\fP ] [ \fI--issuer\fP, \fI-i\fP \fIissuer\fP ] \
+[ \fI--account\fP, \fI-a\fP \fIaccount\fP ] ] [ \fIpass-name\fP ]
 
 Prompt for and insert a new OTP secret into the password store at
-\fIpass-name\fP. The secret must be formatted according to the Key Uri Format;
-see the documentation at
+\fIpass-name\fP.
+
+If \fI--secret\fP is specified, prompt for the \fIsecret\fP value, assuming SHA1
+algorithm, 30-second period, and 6 OTP digits. One or both of \fIissuer\fP and
+\fIaccount\fP must also be specified.
+
+If \fI--secret\fP is not specified, prompt for a key URI; see the documentation at
 .UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
-.UE .
-The URI is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
+.UE
+for the key URI specification.
+
+The secret is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
 when running this command interactively. If \fIpass-name\fP is not specified,
 convert the \fIissuer:accountname\fP URI label to a path in the form of
-\fIisser/accountname\fP. Prompt before overwriting an existing password, unless
+\fIisser/accountname\fP. Prompt before overwriting an existing secret, unless
 \fI--force\fP or \fI-f\fP is specified. This command is alternatively named
 \fBadd\fP.
 
 .TP
-\fBotp append\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \fIpass-name\fP
+\fBotp append\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \
+[ [ \fI--secret\fP, \fI-s\fP ] [ \fI--issuer\fP, \fI-i\fP \fIissuer\fP ] \
+[ \fI--account\fP, \fI-a\fP \fIaccount\fP ] ] \fIpass-name\fP
 
 Append an OTP secret to the password stored in \fIpass-name\fP, preserving any
-existing lines. The secret must be formatted according to the Key Uri Format;
-see the documentation at
+existing lines.
+
+If \fI--secret\fP is specified, prompt for the \fIsecret\fP value, assuming SHA1
+algorithm, 30-second period, and 6 OTP digits. One or both of \fIissuer\fP and
+\fIaccount\fP must also be specified.
+
+If \fI--secret\fP is not specified, prompt for a key URI; see the documentation at
 .UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
-.UE .
+.UE
+for the key URI specification.
+
 The URI is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
 when running this command interactively. Prompt before overwriting an existing
 secret, unless \fI--force\fP or \fI-f\fP is specified.

--- a/test/append.t
+++ b/test/append.t
@@ -14,6 +14,17 @@ test_expect_success 'Reads non-terminal input' '
   [[ $("$PASS" otp uri passfile) == "$uri" ]]
 '
 
+test_expect_success 'Read secret non-terminal input' '
+  existing="foo bar baz"
+  secret=JBSWY3DPEHPK3PXP
+  uri="otpauth://totp/Example:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  "$PASS" otp append -s -i Example -a alice@google.com -e passfile <<< "$secret" &&
+  [[ $("$PASS" otp uri passfile) == "$uri" ]]
+'
+
 test_expect_success 'Reads terminal input in noecho mode' '
   existing="foo bar baz"
   uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"

--- a/test/insert.t
+++ b/test/insert.t
@@ -112,4 +112,22 @@ test_expect_success 'Force overwrites key URI' '
   [[ $("$PASS" show passfile) == "$uri2" ]]
 '
 
+test_expect_success 'Insert passfile from secret with options(issuer, accountname)' '
+  secret="JBSWY3DPEHPK3PXP"
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" otp insert -s -i Example -a alice@google.com passfile <<< "$secret" &&
+   echo [[ $("$PASS" show passfile) == "$uri" ]]
+'
+
+test_expect_success 'Insert from secret without passfile' '
+  secret="JBSWY3DPEHPK3PXP"
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" otp insert -s -i Example -a alice@google.com <<< "$secret" &&
+   echo [[ $("$PASS" show Example/alice@google.com) == "$uri" ]]
+'
+
 test_done


### PR DESCRIPTION
Add --secret, --issuer and --account option which enable insert or append using secret  instead of 
URI.

Almost web service which have two factor authentication provide QR code but It's also provide secret code as an alternative means. 
This PR provide  alternative way to those web service user. And It will solve #31 as well.
