### PR TITLE
Remove pacman database sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ sudo make install
 `pass-otp` is available in the `[community]` repository:
 
 ```
-pacman -Sy pass-otp
+pacman -S pass-otp
 ```
 
 ### macOS


### PR DESCRIPTION
`pacman -Sy pass-otp` leads to partial upgrades which are not supported. Removed and replaced with `pacman -S pass-otp`