### PR TITLE
Fixed lint errors

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -379,9 +379,9 @@ cmd_otp_uri() {
     fi
   done <<< "$contents"
 
-  if [[ clip -eq 1 ]]; then
+  if [[ $clip -eq 1 ]]; then
     clip "$otp_uri" "OTP key URI for $path"
-  elif [[ qrcode -eq 1 ]]; then
+  elif [[ $qrcode -eq 1 ]]; then
     qrcode "$otp_uri" "OTP key URI for $path"
   else
     echo "$otp_uri"


### PR DESCRIPTION
```
$ shellcheck -s bash otp.bash 

In otp.bash line 362:
    -q|--qrcode) qrcode=1; shift ;;
                 ^-- SC2034: qrcode appears unused. Verify it or export it.


In otp.bash line 382:
  if [[ clip -eq 1 ]]; then
        ^-- SC2130: -eq is for integer comparisons. Use = instead.
             ^-- SC2050: This expression is constant. Did you forget the $ on a variable?


In otp.bash line 384:
  elif [[ qrcode -eq 1 ]]; then
          ^-- SC2130: -eq is for integer comparisons. Use = instead.
                 ^-- SC2050: This expression is constant. Did you forget the $ on a variable?
```
