### PR TITLE
Remove test/gnupg/random_seed on clean

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -47,6 +47,7 @@ clean-except-prove-cache:
 
 clean: clean-except-prove-cache
 	$(RM) .prove
+	$(RM) gnupg/random_seed
 
 aggregate-results-and-cleanup: $(T)
 	$(MAKE) aggregate-results


### PR DESCRIPTION
On my system (Debian testing) the file test/gnupg/random_seed remains after running the tests. Added removing it to the clean target.