### PR TITLE
Add target 'test' to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,7 @@ uninstall:
 lint:
 	shellcheck -s bash $(PROG).bash
 
-.PHONY: install uninstall lint
+test:
+	$(MAKE) -C test
+
+.PHONY: install uninstall lint test


### PR DESCRIPTION
Adding a test target to the main `Makefile` makes it more convenient to run the tests in a build environment. As an example: If such a target exists, the Debian build infrastructure runs these test automatically.