### PR TITLE
Build manpage via `make doc` from rst for readability and maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,10 @@ uninstall:
 lint:
 	shellcheck -s bash $(PROG).bash
 
+doc: pass-$(PROG).1
+
+pass-$(PROG).1: pass-$(PROG).1.rst
+	@echo "Building pass-$(PROG) documentation"
+	@rst2man < pass-$(PROG).1.rst > pass-$(PROG).1
+
 .PHONY: install uninstall lint

--- a/pass-otp.1
+++ b/pass-otp.1
@@ -1,135 +1,113 @@
-.TH PASS-OTP 1 "2017 March 19" "Password store OTP extension"
-
+.\" Man page generated from reStructuredText.
+.
+.TH PASS-OTP 1 "2018-02-17" "1.0.0" "Password Store Extension"
 .SH NAME
-pass-otp - A \fBpass\fP(1) extension for managing one-time-password (OTP) tokens.
-
+pass-otp \- A Password Store extension for managing one-time-password (OTP) tokens.
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
 .SH SYNOPSIS
-.B pass otp
-[
-.I COMMAND
-] [
-.I OPTIONS
-]... [
-.I ARGS
-]...
-
+.sp
+pass otp [\fICOMMAND\fP] [\fIOPTIONS\fP]... [\fIARGS\fP]...
 .SH DESCRIPTION
-
-.B pass-otp
-extends the
-.BR pass (1)
-utility with the
-.B otp
-command for adding OTP secrets, generating OTP codes, and displaying secret key
-URIs using the standard \fIotpauth://\fP scheme.
-
-If no COMMAND is specified, COMMAND defaults to \fBcode\fP.
-
+.sp
+pass\-otp extends the \fBpass\fP(1) utility with the otp command for adding OTP secrets, generating OTP codes, and displaying secret key URIs using the standard \fIotpauth://\fP scheme.
+.sp
+If no COMMAND is specified, COMMAND defaults to \fBcode\fP\&.
 .SH COMMANDS
-
-.TP
-\fBotp code\fP [ \fI--clip\fP, \fI-c\fP ] \fIpass-name\fP
-
-Generate and print an OTP code from the secret key stored in \fIpass-name\fP
-using \fBoathtool\fP(1). If \fI--clip\fP or \fI-c\fP is specified, do not print
-the code but instead copy it to the clipboard using \fBxclip\fP(1)
-and then restore the clipboard after 45 (or \fIPASSWORD_STORE_CLIP_TIME\fP)
-seconds. This command is alternatively named \fBshow\fP.
-
-.TP
-\fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \
-[ [ \fI--secret\fP, \fI-s\fP ] [ \fI--issuer\fP, \fI-i\fP \fIissuer\fP ] \
-[ \fI--account\fP, \fI-a\fP \fIaccount\fP ] ] [ \fIpass-name\fP ]
-
-Prompt for and insert a new OTP secret into the password store at
-\fIpass-name\fP.
-
-If \fI--secret\fP is specified, prompt for the \fIsecret\fP value, assuming SHA1
-algorithm, 30-second period, and 6 OTP digits. One or both of \fIissuer\fP and
-\fIaccount\fP must also be specified.
-
-If \fI--secret\fP is not specified, prompt for a key URI; see the documentation at
-.UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
-.UE
-for the key URI specification.
-
-The secret is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
-when running this command interactively. If \fIpass-name\fP is not specified,
-convert the \fIissuer:accountname\fP URI label to a path in the form of
-\fIisser/accountname\fP. Prompt before overwriting an existing secret, unless
-\fI--force\fP or \fI-f\fP is specified. This command is alternatively named
-\fBadd\fP.
-
-.TP
-\fBotp append\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \
-[ [ \fI--secret\fP, \fI-s\fP ] [ \fI--issuer\fP, \fI-i\fP \fIissuer\fP ] \
-[ \fI--account\fP, \fI-a\fP \fIaccount\fP ] ] \fIpass-name\fP
-
-Append an OTP secret to the password stored in \fIpass-name\fP, preserving any
-existing lines.
-
-If \fI--secret\fP is specified, prompt for the \fIsecret\fP value, assuming SHA1
-algorithm, 30-second period, and 6 OTP digits. One or both of \fIissuer\fP and
-\fIaccount\fP must also be specified.
-
-If \fI--secret\fP is not specified, prompt for a key URI; see the documentation at
-.UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
-.UE
-for the key URI specification.
-
-The URI is consumed from stdin; specify \fI--echo\fP or \fI-e\fP to echo input
-when running this command interactively. Prompt before overwriting an existing
-secret, unless \fI--force\fP or \fI-f\fP is specified.
-
-.TP
-\fBotp uri\fP [ \fI--clip\fP, \fI-c\fP | \fI--qrcode\fP, \fI-q\fP ] \fIpass-name\fP
-
-Print the key URI stored in \fIpass-name\fP to stdout. If \fI--clip\fP or
-\fI-c\fP is specified, do not print the URI but instead copy it to the clipboard
-using
-.BR xclip (1)
-and then restore the clipboard after 45 (or \fIPASSWORD_STORE_CLIP_TIME\fP)
-seconds. If \fI--qrcode\fP or \fI-q\fP is specified, do not print the URI but
-instead display a QR code using
-.BR qrencode (1)
-either to the terminal or graphically if supported.
-
-.TP
-\fBotp validate\fP \fIuri\fP
-
-Test a URI string for validity according to the Key Uri Format. For more
-information about this format, see the documentation at
-.UR https://\:github.\:com/\:google/\:google-authenticator/\:wiki/\:Key-Uri-Format
-.UE .
-
+.SS otp code [\-c, \-\-clip] \fIpass\-name\fP
+.sp
+Generate and print an OTP code from the secret key stored in \fIpass\-name\fP using \fBoathtool\fP(1). If \fB\-c\fP (\fB\-\-clip\fP) is specified, do not print the code but instead copy it to the clipboard using \fBxclip\fP(1) and then restore the clipboard after 45 (or \fBPASSWORD_STORE_CLIP_TIME\fP) seconds. This command is alternatively named \fBshow\fP\&.
+.SS otp insert [\-f, \-\-force] [\-e, \-\-echo] [ [\-s, \-\-secret] [\-i, \-\-issuer \fIissuer\fP] [\-a, \-\-account \fIaccount\fP] ] [\fIpass\-name\fP]
+.sp
+Prompt for and insert a new OTP secret into the password store at \fIpass\-name\fP\&.
+.sp
+If \fB\-\-secret\fP is specified, prompt for the \fIsecret\fP value, assuming SHA1 algorithm, 30\-second period, and 6 OTP digits. One or both of \fIissuer\fP and \fIaccount\fP must also be specified.
+.sp
+If \fB\-\-secret\fP is not specified, prompt for a key URI; for the key URI specification see the documentation at
+.sp
+<\fI\%https://github.com/google/google\-authenticator/wiki/Key\-Uri\-Format\fP>
+.sp
+The secret/URI is consumed from stdin; specify \fB\-e\fP (\fB\-\-echo\fP) to echo input when running this command interactively.
+.sp
+If \fIpass\-name\fP is not specified, convert the \fIissuer:accountname\fP URI label to a path in the form of \fIissuer/accountname\fP\&.
+.sp
+Prompt before overwriting an existing secret, unless \fB\-f\fP (\fB\-\-force\fP) is specified. This command is alternatively named \fBadd\fP\&.
+.SS otp append [\-f, \-\-force] [\-e, \-\-echo] [ [\-s, \-\-secret] [\-i, \-\-issuer \fIissuer\fP] [\-a, \-\-account \fIaccount\fP] ] [\fIpass\-name\fP]
+.sp
+Append an OTP secret to the password stored in \fIpass\-name\fP, preserving any existing lines.
+.sp
+If \fB\-\-secret\fP is specified, prompt for the \fIsecret\fP value, assuming SHA1 algorithm, 30\-second period, and 6 OTP digits. One or both of \fIissuer\fP and \fIaccount\fP must also be specified.
+.sp
+If \fB\-\-secret\fP is not specified, prompt for a key URI; for the key URI specification see the documentation at
+.sp
+<\fI\%https://github.com/google/google\-authenticator/wiki/Key\-Uri\-Format\fP>
+.sp
+The secret/URI is consumed from stdin; specify \fB\-e\fP (\fB\-\-echo\fP) to echo input when running this command interactively.
+.sp
+Prompt before overwriting an existing secret, unless \fB\-f\fP (\fB\-\-force\fP) is specified.
+.SS otp uri [\-c, \-\-clip | \-q, \-\-qrcode] \fIpass\-name\fP
+.sp
+Print the key URI stored in \fIpass\-name\fP to stdout. If \fB\-c\fP (\fB\-\-clip\fP) is specified, do not print the URI but instead copy it to the clipboard using \fBxclip\fP(1) and then restore the clipboard after 45 (or \fBPASSWORD_STORE_CLIP_TIME\fP) seconds. If \fB\-q\fP (\fB\-\-qrcode\fP) is specified, do not print the URI but instead display a QR code using \fBqrencode\fP(1) either to the terminal or graphically if supported.
+.SS otp validate \fIuri\fP
+.sp
+Test a URI string for validity according to the Key Uri Format. For more information about this format, see the documentation at
+.sp
+<\fI\%https://github.com/google/google\-authenticator/wiki/Key\-Uri\-Format\fP>
 .SH OPTIONS
-
+.INDENT 0.0
 .TP
-\fBhelp\fP, \fB\-h\fP, \fB\-\-help\fP
+.B help, \-h, \-\-help
 Show usage message.
-
+.UNINDENT
 .SH SEE ALSO
-.BR pass (1),
-.BR qrencode (1),
-.BR zbarimg (1)
-
-.SH AUTHORS
-.B pass-otp
-was written by
-.MT tadfisher@gmail.com
-Tad Fisher
-.ME .
-
+.sp
+\fBpass\fP(1),
+\fBqrencode\fP(1),
+\fBzbarimg\fP(1)
+.sp
+<\fI\%https://github.com/tadfisher/pass\-otp\fP>
 .SH COPYING
+.sp
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-
+.sp
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-
+.sp
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <\fI\%http://www.gnu.org/licenses/\fP>.
+.SH AUTHOR
+Tad Fisher <tadfisher@gmail.com>
+.SH COPYRIGHT
+GPLv3
+.\" Generated by docutils manpage writer.
+.

--- a/pass-otp.1.rst
+++ b/pass-otp.1.rst
@@ -1,0 +1,102 @@
+========
+pass-otp
+========
+ 
+-----------------------------------------------------------------------
+A Password Store extension for managing one-time-password (OTP) tokens.
+-----------------------------------------------------------------------
+ 
+:Author: Tad Fisher <tadfisher@gmail.com>
+:Date:   2018-02-17
+:Copyright: GPLv3
+:Version: 1.0.0
+:Manual section: 1
+:Manual group: Password Store Extension
+ 
+SYNOPSIS
+========
+
+pass otp [`COMMAND`] [`OPTIONS`]... [`ARGS`]...
+
+DESCRIPTION
+===========
+
+pass-otp extends the **pass**\ (1) utility with the otp command for adding OTP secrets, generating OTP codes, and displaying secret key URIs using the standard `otpauth://` scheme.
+
+If no COMMAND is specified, COMMAND defaults to **code**.
+
+COMMANDS
+========
+
+otp code [-c, --clip] `pass-name`
+---------------------------------
+Generate and print an OTP code from the secret key stored in `pass-name` using **oathtool**\ (1). If **-c** (**--clip**) is specified, do not print the code but instead copy it to the clipboard using **xclip**\ (1) and then restore the clipboard after 45 (or **PASSWORD_STORE_CLIP_TIME**) seconds. This command is alternatively named **show**.
+
+otp insert [-f, --force] [-e, --echo] [ [-s, --secret] [-i, --issuer `issuer`] [-a, --account `account`] ] [`pass-name`]
+------------------------------------------------------------------------------------------------------------------------
+Prompt for and insert a new OTP secret into the password store at `pass-name`.
+
+If **--secret** is specified, prompt for the `secret` value, assuming SHA1 algorithm, 30-second period, and 6 OTP digits. One or both of `issuer` and `account` must also be specified.
+
+If **--secret** is not specified, prompt for a key URI; for the key URI specification see the documentation at
+
+<https://github.com/google/google-authenticator/wiki/Key-Uri-Format>
+
+The secret/URI is consumed from stdin; specify **-e** (**--echo**) to echo input when running this command interactively.
+
+If `pass-name` is not specified, convert the `issuer:accountname` URI label to a path in the form of `issuer/accountname`.
+
+Prompt before overwriting an existing secret, unless **-f** (**--force**) is specified. This command is alternatively named **add**.
+
+otp append [-f, --force] [-e, --echo] [ [-s, --secret] [-i, --issuer `issuer`] [-a, --account `account`] ] [`pass-name`]
+------------------------------------------------------------------------------------------------------------------------
+Append an OTP secret to the password stored in `pass-name`, preserving any existing lines.
+
+If **--secret** is specified, prompt for the `secret` value, assuming SHA1 algorithm, 30-second period, and 6 OTP digits. One or both of `issuer` and `account` must also be specified.
+
+If **--secret** is not specified, prompt for a key URI; for the key URI specification see the documentation at
+
+<https://github.com/google/google-authenticator/wiki/Key-Uri-Format>
+
+The secret/URI is consumed from stdin; specify **-e** (**--echo**) to echo input when running this command interactively.
+
+Prompt before overwriting an existing secret, unless **-f** (**--force**) is specified.
+
+otp uri [-c, --clip | -q, --qrcode] `pass-name`
+-----------------------------------------------
+Print the key URI stored in `pass-name` to stdout. If **-c** (**--clip**) is specified, do not print the URI but instead copy it to the clipboard using **xclip**\ (1) and then restore the clipboard after 45 (or **PASSWORD_STORE_CLIP_TIME**) seconds. If **-q** (**--qrcode**) is specified, do not print the URI but instead display a QR code using **qrencode**\ (1) either to the terminal or graphically if supported.
+
+otp validate `uri`
+------------------
+Test a URI string for validity according to the Key Uri Format. For more information about this format, see the documentation at
+
+<https://github.com/google/google-authenticator/wiki/Key-Uri-Format>
+
+OPTIONS
+=======
+
+help, -h, \--help
+  Show usage message.
+
+SEE ALSO
+========
+**pass**\ (1),
+**qrencode**\ (1),
+**zbarimg**\ (1)
+
+<https://github.com/tadfisher/pass-otp>
+
+COPYING
+=======
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
I think this is the approach I'm going to take for my extensions.

The manpage [source](https://github.com/LucidOne/pass-otp/blob/1cd87937d9c8c9073298f43c9e3adf7cb108c1e8/pass-otp.1.rst) looks better than the markdown version and is readable in GitHub.

rst2man is part of `python-docutils` so it would add that as a docbuild dependency, but simply committing `pass-otp.1` would avoid the dependency for most users.

This pull request also "improves" the manpage formatting by removing some of the underlines and other minor changes.