### PR TITLE
Check that test requirements are installed before running additional tests

### DIFF
--- a/test/_requirements.t
+++ b/test/_requirements.t
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+export test_description='Check test requirements'
+
+. ./setup.sh
+
+test_expect_success 'Check that expect is installed' '
+  $(which expect)
+'
+
+test_expect_success 'Check that oathtool is installed' '
+  $(which oathtool)
+'
+
+test_done


### PR DESCRIPTION
This is for everyone running `make test` outside of Travis CI that forgets to install test requirements.
It might make more sense to name it Requirements.t to fix the sort order, but I think it comes down to aesthetics.
