### PR TITLE
fix missing secret name when reading secret in `cmd_otp_append`

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -256,8 +256,9 @@ cmd_otp_append() {
 
   [[ $err -ne 0 || $# -ne 1 ]] && die "Usage: $PROGRAM $COMMAND append [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] pass-name"
 
-  local prompt uri
+  local uri
   local path="${1%/}"
+  local prompt="$path"
   local passfile="$PREFIX/$path.gpg"
 
   [[ -f $passfile ]] || die "Passfile not found"


### PR DESCRIPTION
this patch sets a value for the local variable `prompt` in the function `cmd_otp_append` so that the secret's name/path is displayed correctly when the function `otp_read_secret` or `otp_read_uri` is called in the `cmd_otp_append` workflow.

closes #75