### PR TITLE
Fix append -s behaviour when only one of "account" or "issuer" is provided

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -273,7 +273,11 @@ cmd_otp_append() {
   [[ -n "$existing" ]] && yesno "An OTP secret already exists for $path. Overwrite it?"
 
   if [[ $from_secret -eq 1 ]]; then
-    ([[ -z "$issuer" ]] || [[ -z "$account" ]]) && die "Missing issuer or account"
+    [ -z "$issuer" ] && issuer=false
+    [ -z "$account" ] && account=false
+
+    [ "$issuer" = false ] && [ "$account" = false ] && die "Missing one of either '--issuer' or '--account'"
+
     otp_read_secret "$prompt" $echo "$issuer" "$account"
   else
     otp_read_uri "$prompt" $echo


### PR DESCRIPTION
When https://github.com/tadfisher/pass-otp/issues/68 was closed, only `insert` was fixed.