### PR TITLE
Add openSUSE to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ cd pass-otp
 make install PREFIX=/usr/local
 ```
 
+### openSUSE
+
+```
+zypper install pass-otp
+```
+
 ## Requirements
 
 - `pass` 1.7.0 or later for extension support


### PR DESCRIPTION
I maintain the package for *pass-otp* on *openSUSE*.