### PR TITLE
Added path_prefix for insertions

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -152,7 +152,7 @@ Usage:
         If put on the clipboard, it will be cleared in $CLIP_TIME seconds.
 
     $PROGRAM otp insert [--force,-f] [--echo,-e]
-            [[--secret, -s] [--issuer,-i issuer] [--account,-a account]]
+            [[--secret, -s] [--issuer,-i issuer] [--account,-a account] [--path,-p path-name]]
             [pass-name]
         Prompt for and insert a new OTP key.
 
@@ -208,7 +208,7 @@ cmd_otp_insert() {
     --) shift; break ;;
   esac done
 
-  [[ $err -ne 0 ]] && die "Usage: $PROGRAM $COMMAND insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] [--path,-p path] [pass-name]"
+  [[ $err -ne 0 ]] && die "Usage: $PROGRAM $COMMAND insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] [--path,-p path-name] [pass-name]"
 
   local prompt path uri
   if [[ $# -eq 1 ]]; then

--- a/otp.bash
+++ b/otp.bash
@@ -195,7 +195,7 @@ cmd_otp_version() {
 
 cmd_otp_insert() {
   local opts force=0 echo=0 from_secret=0
-  opts="$($GETOPT -o fesi:a: -l force,echo,secret,issuer:,account: -n "$PROGRAM" -- "$@")"
+  opts="$($GETOPT -o fesi:a:p: -l force,echo,secret,issuer:,account:,path: -n "$PROGRAM" -- "$@")"
   local err=$?
   eval set -- "$opts"
   while true; do case $1 in
@@ -204,10 +204,11 @@ cmd_otp_insert() {
     -s|--secret) from_secret=1; shift;;
     -i|--issuer) issuer=$2; shift; shift;;
     -a|--account) account=$2;  shift; shift;;
+    -p|--path) path_prefix=$2;  shift; shift;;
     --) shift; break ;;
   esac done
 
-  [[ $err -ne 0 ]] && die "Usage: $PROGRAM $COMMAND insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] [pass-name]"
+  [[ $err -ne 0 ]] && die "Usage: $PROGRAM $COMMAND insert [--force,-f] [--echo,-e] [--secret, -s] [--issuer,-i issuer] [--account,-a account] [--path,-p path] [pass-name]"
 
   local prompt path uri
   if [[ $# -eq 1 ]]; then
@@ -231,6 +232,9 @@ cmd_otp_insert() {
   if [[ -z "$path" ]]; then
     [[ -n "$otp_issuer" ]] && path+="$otp_issuer/"
     path+="$otp_accountname"
+    if [ -n "$path_prefix" ]; then
+      path="${path_prefix%/}/$path"
+    fi
     yesno "Insert into $path?"
   fi
 

--- a/pass-otp.1
+++ b/pass-otp.1
@@ -39,7 +39,8 @@ seconds. This command is alternatively named \fBshow\fP.
 .TP
 \fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \
 [ [ \fI--secret\fP, \fI-s\fP ] [ \fI--issuer\fP, \fI-i\fP \fIissuer\fP ] \
-[ \fI--account\fP, \fI-a\fP \fIaccount\fP ] ] [ \fIpass-name\fP ]
+[ \fI--account\fP, \fI-a\fP \fIaccount\fP ] [ \fI--path\fP, \fI-p\fP \fIpath-name\fP ] ] \
+[ \fIpass-name\fP ]
 
 Prompt for and insert a new OTP secret into the password store at
 \fIpass-name\fP.
@@ -59,6 +60,8 @@ convert the \fIissuer:accountname\fP URI label to a path in the form of
 \fIisser/accountname\fP. Prompt before overwriting an existing secret, unless
 \fI--force\fP or \fI-f\fP is specified. This command is alternatively named
 \fBadd\fP.
+
+\fI--path\fP specifies a path prefix to the generated path from the URI label.
 
 .TP
 \fBotp append\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \

--- a/test/insert.t
+++ b/test/insert.t
@@ -139,4 +139,22 @@ test_expect_success 'Tolerates padding in secret' '
   echo [[ $("$PASS" show Example/alice@google.com) == "$uri" ]]
 '
 
+test_expect_success 'Allow path prefixes in insert' '
+  secret="JBSWY3DPEHPK3PXP=="
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" otp insert -s -p totp -i Example -a alice@google.com <<< "$secret" &&
+  echo [[ $("$PASS" show totp/Example/alice@google.com) == "$uri" ]]
+'
+
+test_expect_success 'Allow multiple levels in path prefix' '
+  secret="JBSWY3DPEHPK3PXP=="
+  uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" otp insert -s -p totp/pass-test -i Example -a alice@google.com <<< "$secret" &&
+  echo [[ $("$PASS" show totp/pass-test/Example/alice@google.com) == "$uri" ]]
+'
+
 test_done


### PR DESCRIPTION

When dealing with stdin there isn't a way to tell which directory the OTP codes should go into. This path adds a `-p` switch so one has some options on where the files are stored.

Example: `maim -s | zbarimg -q --raw - | tee >(ykman oath uri) >(pass otp insert -p totp)`

I'll add the required documentation if the patch gets an ACK :)

Signed-off-by: Morten Linderud <morten@linderud.pw>