### PR TITLE
Add debian to the list of distributions with pass-otp packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ pacman -S pass-otp
 
 ### Debian
 
-`pass-otp` is available in `testing` and `sid` repositories with the package-name `pass-extension-otp` according to [tracker](https://tracker.debian.org/pkg/pass-otp):
+`pass-otp` is available in `buster` and `sid` repositories with the package-name `pass-extension-otp` according to [tracker](https://tracker.debian.org/pkg/pass-otp):
+
 ```
 apt install pass-extension-otp
 ```

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ sudo make install
 pacman -S pass-otp
 ```
 
+### Debian
+
+`pass-otp` is available in `testing` and `sid` repositories with the package-name `pass-extension-otp` according to [tracker](https://tracker.debian.org/pkg/pass-otp):
+```
+apt install pass-extension-otp
+```
+
 ### Gentoo Linux
 
 ```


### PR DESCRIPTION
This commit just adds debian to the list of distributions that provide pass-otp packages and also the command to install pass-otp if the user is on testing or sid.