### PR TITLE
Fix installation instructions for Brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ nix-env -i pass-otp
 ### macOS
 #### Brew
 ```
-brew install oath-toolkit
+brew install oath-toolkit bash-completion
 git clone https://github.com/tadfisher/pass-otp
 cd pass-otp
-make install PREFIX=/usr/local
+make install PREFIX=/usr/local BASHCOMPDIR=/usr/local/etc/bash_completion.d
 ```
 
 #### Macports.org

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ nix-env -i pass-otp
 brew install oath-toolkit bash-completion
 git clone https://github.com/tadfisher/pass-otp
 cd pass-otp
-make install PREFIX=/usr/local BASHCOMPDIR=/usr/local/etc/bash_completion.d
+make install PREFIX=$(brew --prefix) BASHCOMPDIR=$(brew --prefix)/etc/bash_completion.d
 ```
 
 #### Macports.org


### PR DESCRIPTION
A user can install Homebrew to a location other than `/usr/local`. The command `brew --prefix` always returns the correct one. That's why `make install PREFIX=$(brew --prefix)` should be used.

Furthermore, `/etc/bash_completion.d` does not exist on macOS and cannot be created without using `sudo`. Thus, installation fails. Homebrew provides the package `bash-completion`. It enables to put additional completions into `$(brew --prefix)/etc/bash_completion.d`.  If Homebrew is used anyway it seems reasonable to use this functionality. 