### PR TITLE
Added TOTP time remaining calc and printout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Generate a 2FA code using this token:
 ```
 $ pass otp totp-secret
 698816
+Expires in 26 seconds
 ```
 
 Display a QR code for an OTP token:

--- a/otp.bash
+++ b/otp.bash
@@ -334,9 +334,11 @@ cmd_otp_code() {
   local cmd
   case "$otp_type" in
     totp)
+      curr_time=$(date +%s)
+      totp_time_remaining=$((30 - ($curr_time % 30)))
       cmd="$OATH -b --totp"
       [[ -n "$otp_algorithm" ]] && cmd+=$(echo "=${otp_algorithm}"|tr "[:upper:]" "[:lower:]")
-      [[ -n "$otp_period" ]] && cmd+=" --time-step-size=$otp_period"s
+      [[ -n "$otp_period" ]] && cmd+=" --time-step-size=$otp_period"s && totp_time_remaining=$(($otp_period - ($curr_time % $otp_period)))
       [[ -n "$otp_digits" ]] && cmd+=" --digits=$otp_digits"
       cmd+=" $otp_secret"
       ;;
@@ -369,8 +371,10 @@ cmd_otp_code() {
 
   if [[ $clip -ne 0 ]]; then
     clip "$out" "OTP code for $path"
+    [[ -n "$totp_time_remaining" ]] && echo "Expires in $totp_time_remaining seconds"
   else
     echo "$out"
+    [[ -n "$totp_time_remaining" ]] && echo "Expires in $totp_time_remaining seconds"
   fi
 }
 

--- a/otp.bash
+++ b/otp.bash
@@ -335,10 +335,10 @@ cmd_otp_code() {
   case "$otp_type" in
     totp)
       curr_time=$(date +%s)
-      totp_time_remaining=$((30 - ($curr_time % 30)))
+      totp_time_remaining=$((30 - (curr_time % 30)))
       cmd="$OATH -b --totp"
       [[ -n "$otp_algorithm" ]] && cmd+=$(echo "=${otp_algorithm}"|tr "[:upper:]" "[:lower:]")
-      [[ -n "$otp_period" ]] && cmd+=" --time-step-size=$otp_period"s && totp_time_remaining=$(($otp_period - ($curr_time % $otp_period)))
+      [[ -n "$otp_period" ]] && cmd+=" --time-step-size=$otp_period"s && totp_time_remaining=$((otp_period - (curr_time % otp_period)))
       [[ -n "$otp_digits" ]] && cmd+=" --digits=$otp_digits"
       cmd+=" $otp_secret"
       ;;

--- a/test/code.t
+++ b/test/code.t
@@ -15,7 +15,7 @@ test_expect_success 'Generates TOTP code' '
 
   test_pass_init &&
   "$PASS" otp insert passfile <<< "$uri" &&
-  code=$("$PASS" otp passfile) &&
+  code=$("$PASS" otp passfile | head -n 1) &&
   [[ ${#code} -eq 6 ]]
 '
 


### PR DESCRIPTION
In reference to feature request #94. I've added a TOTP time remaining calculation and the accompanying printout to TOTP code requests.

This adds a reliance on the system date program to print out the current unix time.