### PR TITLE
Update install instructions for macOS/Brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,7 @@ environment via `nix-shell`.
 ### macOS
 #### Brew
 ```
-brew install oath-toolkit bash-completion
-git clone https://github.com/tadfisher/pass-otp
-cd pass-otp
-make install PREFIX=$(brew --prefix) BASHCOMPDIR=$(brew --prefix)/etc/bash_completion.d
+brew install pass-otp
 ```
 
 #### Macports.org


### PR DESCRIPTION
Now available as a formula directly: https://brewformulas.org/PassOtp