### PR TITLE
Mention that GNU make is required to run make test

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ URL=https://raw.githubusercontent.com/beli3ver/crux-ports/master/
   - `git`
   - `oathtool`
   - `expect`
+  - `make` (GNU make)
 - `make lint`
   - `shellcheck`
 


### PR DESCRIPTION
The test makefile is not compatible with other makes like [bmake](man.freebsd.org/make/1), which is the default make on FreeBSD.