### PR TITLE
Add support for quiet output of otp code command

### DIFF
--- a/pass-otp.1
+++ b/pass-otp.1
@@ -28,13 +28,15 @@ If no COMMAND is specified, COMMAND defaults to \fBcode\fP.
 .SH COMMANDS
 
 .TP
-\fBotp code\fP [ \fI--clip\fP, \fI-c\fP ] \fIpass-name\fP
+\fBotp code\fP [ \fI--clip\fP, \fI-c\fP ] [ \fI--quiet\fP, \fI-q\fP ] \fIpass-name\fP
 
 Generate and print an OTP code from the secret key stored in \fIpass-name\fP
 using \fBoathtool\fP(1). If \fI--clip\fP or \fI-c\fP is specified, do not print
 the code but instead copy it to the clipboard using \fBxclip\fP(1)
 and then restore the clipboard after 45 (or \fIPASSWORD_STORE_CLIP_TIME\fP)
-seconds. This command is alternatively named \fBshow\fP.
+seconds. If \fI--quiet\fP or \fI-q\fP is specified, do not print
+the git update message to standard out. This command is alternatively named
+\fBshow\fP.
 
 .TP
 \fBotp insert\fP [ \fI--force\fP, \fI-f\fP ] [ \fI--echo\fP, \fI-e\fP ] \

--- a/pass-otp.bash.completion
+++ b/pass-otp.bash.completion
@@ -20,7 +20,7 @@ __password_store_extension_complete_otp() {
         ;;
     esac
   else
-      COMPREPLY+=($(compgen -W "insert append uri validate -h --help -c --clip" -- ${cur}))
+      COMPREPLY+=($(compgen -W "insert append uri validate -h --help -c --clip -q --quiet" -- ${cur}))
       _pass_complete_entries 1
   fi
 }

--- a/test/code.t
+++ b/test/code.t
@@ -30,6 +30,17 @@ test_expect_success 'Generates HOTP code and increments counter' '
   [[ $("$PASS" otp uri passfile) == "$inc" ]]
 '
 
+test_expect_success 'Generates HOTP code quietly' '
+  uri="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=10&issuer=Example"
+  inc="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=11&issuer=Example"
+
+  test_pass_git_init &&
+  "$PASS" otp insert passfile <<< "$uri" &&
+  code=$("$PASS" otp -q passfile) &&
+  [[ ${#code} -eq 6 ]] &&
+  [[ $("$PASS" otp uri passfile) == "$inc" ]]
+'
+
 test_expect_success 'HOTP counter increments and preserves multiline contents' '
   uri="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=10&issuer=Example"
   inc="otpauth://hotp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&counter=11&issuer=Example"

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -72,3 +72,8 @@ test_pass_init() {
   rm -rf "$PASSWORD_STORE_DIR"
   "$PASS" init "${KEY[@]}"
 }
+
+test_pass_git_init() {
+    rm -rf "$PASSWORD_STORE_DIR"
+    "$PASS" init "${KEY[@]}" && "$PASS" git init
+}


### PR DESCRIPTION
When using this option the output of `pass otp -q ...` is predictable and can be
further used without parsing even when the password store is a repository as
well.  This is useful, for example, when using rofi-pass.

The patch is written in a way that other commands can optionally use the quiet
option for otp_insert as well.