### PR TITLE
OpenBSD patches to installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 PROG ?= otp
-PREFIX ?= /usr
+PREFIX ?= /usr/local
 DESTDIR ?=
 LIBDIR ?= $(PREFIX)/lib
 SYSTEM_EXTENSION_DIR ?= $(LIBDIR)/password-store/extensions
-MANDIR ?= $(PREFIX)/share/man
+MANDIR ?= $(PREFIX)/man
 BASHCOMPDIR ?= /etc/bash_completion.d
 
 all:
@@ -15,17 +15,17 @@ all:
 	@echo "     password store"
 
 install:
-	@install -v -d "$(DESTDIR)$(MANDIR)/man1" && install -m 0644 -v pass-$(PROG).1 "$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"
-	@install -v -d "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/"
-	@install -v -m0755 $(PROG).bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash"
-	@install -v -d "$(DESTDIR)$(BASHCOMPDIR)/"
-	@install -v -m 644 pass-otp.bash.completion  "$(DESTDIR)$(BASHCOMPDIR)/pass-otp"
+	install -d "$(DESTDIR)$(MANDIR)/man1" && install -m 0644 pass-$(PROG).1 "$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"
+	install -d "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/"
+	install -m0755 $(PROG).bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash"
+	install -d "$(DESTDIR)$(BASHCOMPDIR)/"
+	install -m 644 pass-otp.bash.completion  "$(DESTDIR)$(BASHCOMPDIR)/pass-otp"
 	@echo
 	@echo "pass-$(PROG) is installed succesfully"
 	@echo
 
 uninstall:
-	@rm -vrf \
+	rm -vrf \
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash" \
 		"$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"
 		"$(DESTDIR)$(BASHCOMPDIR)/pass-otp"


### PR DESCRIPTION
OpenBSD's install(8) doesn't have "-v:     print the name of each directory as it is created", so instead just rely on make's built in reporting of what it's doing.

I don't know if you want these patches, but you can't install pass-otp on OpenBSD without them, so I'd like to leave them here at least for future travellers.