### PR TITLE
Suggest to install without root permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ sudo make install
 or, to install in the user dir (following the standard XDG base directory paths):
 
 ```
-PREFIX=$XDG_DATA_HOME \
+$ echo $XDG_DATA_HOME
+/home/$USER/.local/share
+
+$ PREFIX=$XDG_DATA_HOME \
     LIBDIR=$PREFIX \
     MANDIR=$XDG_DATA_HOME/man \
     BASHCOMPDIR=$XDG_DATA_HOME/bash-completion.d \

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ or, to install in the user dir (following the standard XDG base directory paths)
 $ echo $XDG_DATA_HOME
 /home/$USER/.local/share
 
+$ export PASSWORD_STORE_ENABLE_EXTENSIONS=true
+$ export PASSWORD_STORE_EXTENSIONS_DIR=$XDG_DATA_HOME/password-store/extensions
+
 $ PREFIX=$XDG_DATA_HOME \
     LIBDIR=$PREFIX \
     MANDIR=$XDG_DATA_HOME/man \

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ $ echo $XDG_DATA_HOME
 /home/$USER/.local/share
 
 $ export PASSWORD_STORE_ENABLE_EXTENSIONS=true
-$ export PASSWORD_STORE_EXTENSIONS_DIR=$XDG_DATA_HOME/password-store/extensions
+$ export PASSWORD_STORE_EXTENSIONS_DIR=$XDG_DATA_HOME/password-store/.extensions
 $ export BASH_COMPLETION_USER_DIR=$XDG_DATA_HOME/bash-completion/completions
 
 $ PREFIX=$XDG_DATA_HOME \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 | Branch | Status |
 |--------|--------|
 | [**master**](https://github.com/tadfisher/pass-otp/tree/master) | [![Build Status: master](https://travis-ci.org/tadfisher/pass-otp.svg?branch=master)](https://travis-ci.org/tadfisher/pass-otp) |
@@ -113,6 +112,16 @@ $ pass otp uri -q totp-secret
 git clone https://github.com/tadfisher/pass-otp
 cd pass-otp
 sudo make install
+```
+
+or, to install in the user dir (following the standard XDG base directory paths):
+
+```
+PREFIX=$XDG_DATA_HOME \
+    LIBDIR=$PREFIX \
+    MANDIR=$XDG_DATA_HOME/man \
+    BASHCOMPDIR=$XDG_DATA_HOME/bash-completion.d \
+    make install
 ```
 
 ### Arch Linux

--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ $ echo $XDG_DATA_HOME
 
 $ export PASSWORD_STORE_ENABLE_EXTENSIONS=true
 $ export PASSWORD_STORE_EXTENSIONS_DIR=$XDG_DATA_HOME/password-store/extensions
+$ export BASH_COMPLETION_USER_DIR=$XDG_DATA_HOME/bash-completion/completions
 
 $ PREFIX=$XDG_DATA_HOME \
     LIBDIR=$PREFIX \
     MANDIR=$XDG_DATA_HOME/man \
-    BASHCOMPDIR=$XDG_DATA_HOME/bash-completion.d \
+    BASHCOMPDIR=$BASH_COMPLETION_USER_DIR \
     make install
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ $ export BASH_COMPLETION_USER_DIR=$XDG_DATA_HOME/bash-completion/completions
 
 $ PREFIX=$XDG_DATA_HOME \
     LIBDIR=$PREFIX \
-    MANDIR=$XDG_DATA_HOME/man \
     BASHCOMPDIR=$BASH_COMPLETION_USER_DIR \
     make install
 ```


### PR DESCRIPTION
I'd like to easily install `pass-otp` without requiring root access and respecting XDG base dir specs.

This is my attempt to do that without touching the code, rather playing a bit with env vars 