### PR TITLE
Use command -v instead of which to prevent errors on stderr

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -17,8 +17,8 @@
 # []
 
 VERSION="1.1.2"
-OATH=$(which oathtool)
-OTPTOOL=$(which otptool)
+OATH=$(command -v oathtool)
+OTPTOOL=$(command -v otptool)
 
 ## source:  https://gist.github.com/cdown/1163649
 urlencode() {


### PR DESCRIPTION
I upgraded to a more recent version of otp.bash and now I'm getting an error message like this preceding my otp output:
```
which: no otptool in (/home/evan/.local/bin:/home/evan/go/bin:/usr/share/Modules/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin)
```

This fixes the issue by using `command -v` instead of `which`; it's also possible to fix this by redirecting which stderr to `/dev/null`, but using `command` instead of `which` is better anyway because `command` is a bash builtin.