### PR TITLE
update link for ZBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Pipe an `otpauth://` URI into a passfile:
 $ pass otp insert totp-secret < totp-secret.txt
 ```
 
-Use [zbar](http://zbar.sourceforge.net/) to decode a QR image or webcam shot into a passfile:
+Use [zbar](https://github.com/mchehab/zbar) to decode a QR image or webcam shot into a passfile:
 
 ```
 $ zbarimg -q --raw qrcode.png | pass otp insert totp-secret


### PR DESCRIPTION
Quoting from the README at the new link:

> As its development stopped in 2012, I took the task of keeping it updated with the V4L2 API. This is the main repository for it.