### PR TITLE
Use `command -v` instead of `which`

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # []
 
-VERSION="1.1.2"
+VERSION="1.2.0"
 OATH=$(command -v oathtool)
 OTPTOOL=$(command -v otptool)
 

--- a/otp.bash
+++ b/otp.bash
@@ -17,8 +17,8 @@
 # []
 
 VERSION="1.1.2"
-OATH=$(which oathtool)
-OTPTOOL=$(which otptool)
+OATH=$(command -v oathtool)
+OTPTOOL=$(command -v otptool)
 
 ## source:  https://gist.github.com/cdown/1163649
 urlencode() {


### PR DESCRIPTION
This is a more correct approach to check if some command is present since it doesn't print anything to stdout if the command isn't present.Use `command -v` instead of `which`. This is focuses on suppressing the error messages produced by `which`:
```
zneix@uds ~/a/pass-otp (master)$ pass otp otp/discord
which: no otptool in (/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/zneix/.local/bin:/home/zneix/scripts:/home/zneix/.local/share/go/bin)
821264
zneix@uds ~/a/pass-otp (master)$
```
This is a more correct approach to check if some command is present since it doesn't print anything to stdout if the command isn't present.
More reference: https://stackoverflow.com/a/37056347

Update version variable
Last git release is 1.2.0 and the variable itself was outdated

Nevermind, duplicate of #116, #123, #159... I really think `command -v` is a better approach than `which` but oh well.