### PR TITLE
Fix HOTP counter increases

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -370,7 +370,7 @@ cmd_otp_code() {
 
   if [[ "$otp_type" == "hotp" ]]; then
     # Increment HOTP counter in-place
-    local line replaced uri=${otp_uri/&counter=$otp_counter/&counter=$counter}
+    local line replaced uri=${otp_uri/&counter=$otp_counter/"&counter=$counter"}
     while IFS= read -r line; do
       [[ "$line" == otpauth://* ]] && line="$uri"
       [[ -n "$replaced" ]] && replaced+=$'\n'


### PR DESCRIPTION
When substituting the counter in a HOTP uri, the replacement string needs to be quoted because it contains a `&`. Quoting it will avoid `&` to be replaced with the matching portion of the pattern. 

See:
https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

Fixes #171 