### PR TITLE
Fix typos, links, errors, warnings, safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	install -d "$(DESTDIR)$(BASHCOMPDIR)/"
 	install -m 644 pass-otp.bash.completion  "$(DESTDIR)$(BASHCOMPDIR)/pass-otp"
 	@echo
-	@echo "pass-$(PROG) is installed succesfully"
+	@echo "pass-$(PROG) is installed successfully"
 	@echo
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ with pkgs;
 pass.withExtensions (exts: [ exts.pass-otp ])
 ```
 
-The above can be installed imperatively via `nix-env` or ran in a temprorary
+The above can be installed imperatively via `nix-env` or ran in a temporary
 environment via `nix-shell`.
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ apt install pass-extension-otp
 
 ### Fedora
 
-`pass-otp` is available in Fedora 28 and up, under the package name `pass-otp` according to [Fedora Apps](https://apps.fedoraproject.org/packages/pass-otp).
+`pass-otp` is available in Fedora 28 and up, under the package name `pass-otp` according to [Fedora Apps](https://packages.fedoraproject.org/pkgs/pass-otp/).
 
 ```
 dnf install pass-otp

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,6 @@
 , gnupg
 , pass
 , shellcheck
-, which
 }:
 
 stdenv.mkDerivation {
@@ -33,7 +32,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   patchPhase = ''
-    sed -i -e 's|OATH=\$(which oathtool)|OATH=${oathToolkit}/bin/oathtool|' otp.bash
+    sed -i -e 's|OATH=\$(command -v oathtool)|OATH=${oathToolkit}/bin/oathtool|' otp.bash
   '';
 
   checkPhase = ''

--- a/otp.bash
+++ b/otp.bash
@@ -13,7 +13,7 @@
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # []
 
 VERSION="1.1.2"

--- a/otp.bash
+++ b/otp.bash
@@ -17,8 +17,8 @@
 # []
 
 VERSION="1.1.2"
-OATH=$(which oathtool)
-OTPTOOL=$(which otptool)
+OATH=$(command -v oathtool)
+OTPTOOL=$(command -v otptool)
 
 ## source:  https://gist.github.com/cdown/1163649
 urlencode() {

--- a/otp.bash
+++ b/otp.bash
@@ -342,6 +342,12 @@ cmd_otp_code() {
     fi
   done < <(echo "$contents")
 
+  # Check oathtool for stdin secrets feature
+  OATH_SAFE_VERSION=2.6.5
+  OATH_VERSION=$("$OATH" --version | head -n1 | tr ' ' '\n' | tail -n1)
+  printf -v OATH_VERSIONS '%s\n%s' "$OATH_SAFE_VERSION" "$OATH_VERSION"
+  [[ "$OATH_VERSIONS" = "$(sort -n <<< "$OATH_VERSIONS")" ]] && OATH_SAFE=1
+
   local cmd
   case "$otp_type" in
     totp)
@@ -350,7 +356,12 @@ cmd_otp_code() {
       [[ -n "$otp_algorithm" ]] && cmd+=(--totp="$(echo "${otp_algorithm}"|tr "[:upper:]" "[:lower:]")")
       [[ -n "$otp_period" ]] && cmd+=(--time-step-size="$otp_period"s)
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
-      cmd+=("$otp_secret")
+      if [[ -n "$OATH_SAFE" ]] ; then
+        cmd+=(-) # secrets on stdin
+        unset OTPTOOL
+      else
+        cmd+=("$otp_secret")
+      fi
       [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
@@ -358,7 +369,12 @@ cmd_otp_code() {
       local counter=$((otp_counter+1))
       cmd=("$OATH" --base32 --hotp --counter="$counter")
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
-      cmd+=("$otp_secret")
+      if [[ -n "$OATH_SAFE" ]] ; then
+        cmd+=(-) # secrets on stdin
+        unset OTPTOOL
+      else
+        cmd+=("$otp_secret")
+      fi
       [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
@@ -367,7 +383,12 @@ cmd_otp_code() {
       ;;
   esac
 
-  local out; out=$("${cmd[@]}") || die "$path: failed to generate OTP code."
+  local out
+  if [[ -n "$OATH" && -n "$OATH_SAFE" && -z "$OTPTOOL" ]] ; then
+    out=$("${cmd[@]}" <<< "$otp_secret") || die "$path: failed to generate OTP code."
+  else
+    out=$("${cmd[@]}") || die "$path: failed to generate OTP code."
+  fi
 
   if [[ "$otp_type" == "hotp" ]]; then
     # Increment HOTP counter in-place

--- a/otp.bash
+++ b/otp.bash
@@ -345,20 +345,21 @@ cmd_otp_code() {
   local cmd
   case "$otp_type" in
     totp)
-      cmd="$OATH -b --totp"
-      [[ -n "$otp_algorithm" ]] && cmd+=$(echo "=${otp_algorithm}"|tr "[:upper:]" "[:lower:]")
-      [[ -n "$otp_period" ]] && cmd+=" --time-step-size=$otp_period"s
-      [[ -n "$otp_digits" ]] && cmd+=" --digits=$otp_digits"
-      cmd+=" $otp_secret"
-      [[ -n "$OTPTOOL" ]] && cmd="$OTPTOOL $uri"
+      cmd=("$OATH" --base32)
+      [[ -z "$otp_algorithm" ]] && cmd+=(--totp)
+      [[ -n "$otp_algorithm" ]] && cmd+=(--totp="$(echo "${otp_algorithm}"|tr "[:upper:]" "[:lower:]")")
+      [[ -n "$otp_period" ]] && cmd+=(--time-step-size="$otp_period"s)
+      [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
+      cmd+=("$otp_secret")
+      [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
     hotp)
       local counter=$((otp_counter+1))
-      cmd="$OATH -b --hotp --counter=$counter"
-      [[ -n "$otp_digits" ]] && cmd+=" --digits=$otp_digits"
-      cmd+=" $otp_secret"
-      [[ -n "$OTPTOOL" ]] && cmd="$OTPTOOL $uri"
+      cmd=("$OATH" --base32 --hotp --counter="$counter")
+      [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
+      cmd+=("$otp_secret")
+      [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
     *)
@@ -366,7 +367,7 @@ cmd_otp_code() {
       ;;
   esac
 
-  local out; out=$($cmd) || die "$path: failed to generate OTP code."
+  local out; out=$("${cmd[@]}") || die "$path: failed to generate OTP code."
 
   if [[ "$otp_type" == "hotp" ]]; then
     # Increment HOTP counter in-place

--- a/otp.bash
+++ b/otp.bash
@@ -314,7 +314,7 @@ cmd_otp_append() {
 }
 
 cmd_otp_code() {
-  [[ -z "$OATH" ]] && die "Failed to generate OTP code: oathtool is not installed."
+  [[ -z "$OATH" && -z "$OTPTOOL" ]] && die "Failed to generate OTP code: oathtool or otptool is not installed."
 
   local opts clip=0 quiet=0
   opts="$($GETOPT -o cq -l clip,quiet -n "$PROGRAM" -- "$@")"

--- a/pass-otp.1
+++ b/pass-otp.1
@@ -137,4 +137,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see http://www.gnu.org/licenses/ .
+# along with this program.  If not, see https://www.gnu.org/licenses/ .
 
 SHELL ?= /bin/bash
 SHELL_PATH ?= $(SHELL)


### PR DESCRIPTION
- Fix typos
- Update http URLs to https
- Fix link to the Fedora pass-otp package
- Do not fail when otptool is installed but oathtool is not installed
- Use `command -v` instead of `which` for finding programs
- Use bash arrays to separate arguments to oathtool and otptool
- Send secrets to oathtool via stdin instead of command-line arguments
