### PR TITLE
Fix Nix package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
 , gnupg
 , pass
 , shellcheck
+, which
 }:
 
 stdenv.mkDerivation {


### PR DESCRIPTION
Was broken in 1e269f4d6e5451f4ca593d13f33f30c73dfe87bc

Resolved by adding back the which input, since the tests use it