### PR TITLE
Do not use oathtool if it is not available.

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -362,10 +362,12 @@ cmd_otp_code() {
   done < <(echo "$contents")
 
   # Check oathtool for stdin secrets feature
-  OATH_SAFE_VERSION=2.6.5
-  OATH_VERSION=$("$OATH" --version | head -n1 | tr ' ' '\n' | tail -n1)
-  printf -v OATH_VERSIONS '%s\n%s' "$OATH_SAFE_VERSION" "$OATH_VERSION"
-  [[ "$OATH_VERSIONS" = "$(sort -n <<< "$OATH_VERSIONS")" ]] && OATH_SAFE=1
+  if [[ -n "$OATH" ]]; then
+    OATH_SAFE_VERSION=2.6.5
+    OATH_VERSION=$("$OATH" --version | head -n1 | tr ' ' '\n' | tail -n1)
+    printf -v OATH_VERSIONS '%s\n%s' "$OATH_SAFE_VERSION" "$OATH_VERSION"
+    [[ "$OATH_VERSIONS" = "$(sort -n <<< "$OATH_VERSIONS")" ]] && OATH_SAFE=1
+  fi
 
   local cmd
   case "$otp_type" in


### PR DESCRIPTION
The code testing for *oathtool* version compatibility with stdin must not use the tool if it is not available.

Following code (especially building `cmd`) looks slightly odd in this regard but is fine since it never executes. If neither oathtool not otptool are available the code will exit early due to the guard in the first line of the function. Any `cmd` generated for *oathtool* will be dropped with a full reassignment if *otptool* is available. The code executing the `cmd` does only check to test for stdin feature availability, and thus will never execute *oathtool* if *otptool* is available due to the reassignment.

---

The above is the commit message verbatim.

For the record, this issue was introduced with the latest (as of writing) commit (7bb50dbc4b6073f12f40be66a5ee371b9652a646).

I was thinking about rearranging the `case` below to make it more readable (i.e. not silently overwrite the `cmd` near the end), but it didn't seem worth it.

---

It should also be noted that there is no `set -e` in effect, which means that without this patch code execution looks something like this:

```console
% pass otp top/steam
[…]/lib/password-store/extensions/otp.bash: line 366: : command not found
QXX8B
```

I highly recommend rewriting this at some point to ensure that any errors like this actually err out instead of continuing execution, potentially causing unintended (possibly damaging) consequences.