### PR TITLE
Avoid leaking the OTP secret if there's a parsing problem.

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -56,7 +56,7 @@ otp_parse_uri() {
   uri="${uri//\"/%22}"
 
   local pattern='^otpauth:\/\/(totp|hotp)(\/(([^:?]+)?(:([^:?]*))?)(:([0-9]+))?)?\?(.+)$'
-  [[ "$uri" =~ $pattern ]] || die "Cannot parse OTP key URI: $uri"
+  [[ "$uri" =~ $pattern ]] || die "Cannot parse OTP key URI"
 
   otp_uri=${BASH_REMATCH[0]}
   otp_type=${BASH_REMATCH[1]}
@@ -64,7 +64,7 @@ otp_parse_uri() {
 
   otp_accountname=$(urldecode "${BASH_REMATCH[6]}")
   [[ -z $otp_accountname ]] && otp_accountname=$(urldecode "${BASH_REMATCH[4]}") || otp_issuer=$(urldecode "${BASH_REMATCH[4]}")
-  [[ -z $otp_accountname ]] && die "Invalid key URI (missing accountname): $otp_uri"
+  [[ -z $otp_accountname ]] && die "Invalid key URI (missing accountname)"
 
   local p=${BASH_REMATCH[9]}
   local params
@@ -85,10 +85,10 @@ otp_parse_uri() {
     fi
   done
 
-  [[ -z "$otp_secret" ]] && die "Invalid key URI (missing secret): $otp_uri"
+  [[ -z "$otp_secret" ]] && die "Invalid key URI (missing secret)"
 
   pattern='^[0-9]+$'
-  [[ "$otp_type" == 'hotp' ]] && [[ ! "$otp_counter" =~ $pattern ]] && die "Invalid key URI (missing counter): $otp_uri"
+  [[ "$otp_type" == 'hotp' ]] && [[ ! "$otp_counter" =~ $pattern ]] && die "Invalid key URI (missing counter)"
 }
 
 otp_read_uri() {


### PR DESCRIPTION
pass-otp leaks secrets on parsing problems.

Just, for an example from the wild, I scanned a TOTP secret made by Gitea and it gave me

```
<a href='otpauth://totp/git.tilde.org%20%28git.tilde.org%29:kousu?algorithm=SHA1&amp;digits=6&amp;issuer=git.tilde.org%20%28git.tilde.org%29&amp;period=30&amp;secret=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>otpauth://totp/git.tilde.org%20%28git.tilde.org%29:kousu?algorithm=SHA1&amp;digits=6&amp;issuer=git.tilde.org%20%28git.tilde.org%29&amp;period=30&amp;secret=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</a>
```

My scanner app showed me this whole thing and I, not thinking that closely, snipped off the `<a href='` but left the rest, and the first time I tried to use it I got

```
$ pass otp -c git.tilde.org
Invalid key URI (missing secret): <a href='otpauth://totp/git.tilde.org%20%28git.tilde.org%29:kousu?algorithm=SHA1&amp;digits=6&amp;issuer=git.tilde.org%20%28git.tilde.org%29&amp;period=30&amp;secret=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>otpauth://totp/git.tilde.org%20%28git.tilde.org%29:kousu?algorithm=SHA1&amp;digits=6&amp;issuer=git.tilde.org%20%28git.tilde.org%29&amp;period=30&amp;secret=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</a
```

I mean it's not a big deal since I'm enrolling so the code is already displayed as a QR and text and text again on my screen and Gitea forces me to test it, but this seems like an easy thing to avoid.