### PR TITLE
Correctly parse secrets containing url-encoded padding

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -74,7 +74,7 @@ otp_parse_uri() {
   for param in "${params[@]}"; do
     if [[ "$param" =~ $pattern ]]; then
       case ${BASH_REMATCH[1]} in
-        secret) otp_secret=${BASH_REMATCH[2]} ;;
+        secret) otp_secret=$(urldecode "${BASH_REMATCH[2]}") ;;
         digits) otp_digits=${BASH_REMATCH[2]} ;;
         algorithm) otp_algorithm=${BASH_REMATCH[2]} ;;
         period) otp_period=${BASH_REMATCH[2]} ;;


### PR DESCRIPTION
Sometimes the secret in the otpauth:// URI contains padding ("="). Even though this is unnecessary, it is not forbidden and oathtool accepts this padding. The padding should be URL encoded, and if passed directly to oathtool it results in errors like:

    /usr/bin/oathtool: base32 decoding failed: Base32 string is invalid

Passing the secret through urldecode avoids this problem.