### PR TITLE
Always provide secrets to oathtool over stdin, and drop support for otptool

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ URL=https://git.malte-kiefer.de/crux-ports/plain
 ## Requirements
 
 - `pass` 1.7.0 or later for extension support
-- `oathtool` or `Pass::OTP` for generating 2FA codes
+- `oathtool` for generating 2FA codes
 - `qrencode` for generating QR code images
 
 ### Build requirements

--- a/otp.bash
+++ b/otp.bash
@@ -329,7 +329,7 @@ cmd_otp_append() {
 }
 
 cmd_otp_code() {
-  [[ -z "$OATH" && -z "$OTPTOOL" ]] && die "Failed to generate OTP code: oathtool or otptool is not installed."
+  [[ -z "$OATH" ]] && die "Failed to generate OTP code: oathtool is not installed."
 
   local opts clip=0 quiet=0
   opts="$($GETOPT -o cq -l clip,quiet -n "$PROGRAM" -- "$@")"

--- a/otp.bash
+++ b/otp.bash
@@ -18,7 +18,6 @@
 
 VERSION="1.1.2"
 OATH=$(command -v oathtool)
-OTPTOOL=$(command -v otptool)
 
 if [[ $PASSAGE == 1 ]]; then
   EXT="age"
@@ -355,7 +354,6 @@ cmd_otp_code() {
   fi
   while read -r line; do
     if [[ "$line" == otpauth://* ]]; then
-      local uri="$line"
       otp_parse_uri "$line"
       break
     fi
@@ -370,7 +368,6 @@ cmd_otp_code() {
       [[ -n "$otp_period" ]] && cmd+=(--time-step-size="$otp_period"s)
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
       cmd+=("$otp_secret")
-      [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
     hotp)
@@ -378,7 +375,6 @@ cmd_otp_code() {
       cmd=("$OATH" --base32 --hotp --counter="$counter")
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
       cmd+=("$otp_secret")
-      [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
     *)

--- a/otp.bash
+++ b/otp.bash
@@ -361,12 +361,6 @@ cmd_otp_code() {
     fi
   done < <(echo "$contents")
 
-  # Check oathtool for stdin secrets feature
-  OATH_SAFE_VERSION=2.6.5
-  OATH_VERSION=$("$OATH" --version | head -n1 | tr ' ' '\n' | tail -n1)
-  printf -v OATH_VERSIONS '%s\n%s' "$OATH_SAFE_VERSION" "$OATH_VERSION"
-  [[ "$OATH_VERSIONS" = "$(sort -n <<< "$OATH_VERSIONS")" ]] && OATH_SAFE=1
-
   local cmd
   case "$otp_type" in
     totp)
@@ -375,12 +369,7 @@ cmd_otp_code() {
       [[ -n "$otp_algorithm" ]] && cmd+=(--totp="$(echo "${otp_algorithm}"|tr "[:upper:]" "[:lower:]")")
       [[ -n "$otp_period" ]] && cmd+=(--time-step-size="$otp_period"s)
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
-      if [[ -n "$OATH_SAFE" ]] ; then
-        cmd+=(-) # secrets on stdin
-        unset OTPTOOL
-      else
-        cmd+=("$otp_secret")
-      fi
+      cmd+=("$otp_secret")
       [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
@@ -388,12 +377,7 @@ cmd_otp_code() {
       local counter=$((otp_counter+1))
       cmd=("$OATH" --base32 --hotp --counter="$counter")
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
-      if [[ -n "$OATH_SAFE" ]] ; then
-        cmd+=(-) # secrets on stdin
-        unset OTPTOOL
-      else
-        cmd+=("$otp_secret")
-      fi
+      cmd+=("$otp_secret")
       [[ -n "$OTPTOOL" ]] && cmd=("$OTPTOOL" "$uri")
       ;;
 
@@ -402,12 +386,7 @@ cmd_otp_code() {
       ;;
   esac
 
-  local out
-  if [[ -n "$OATH" && -n "$OATH_SAFE" && -z "$OTPTOOL" ]] ; then
-    out=$("${cmd[@]}" <<< "$otp_secret") || die "$path: failed to generate OTP code."
-  else
-    out=$("${cmd[@]}") || die "$path: failed to generate OTP code."
-  fi
+  local out; out=$("${cmd[@]}") || die "$path: failed to generate OTP code."
 
   if [[ "$otp_type" == "hotp" ]]; then
     # Increment HOTP counter in-place

--- a/otp.bash
+++ b/otp.bash
@@ -367,14 +367,14 @@ cmd_otp_code() {
       [[ -n "$otp_algorithm" ]] && cmd+=(--totp="$(echo "${otp_algorithm}"|tr "[:upper:]" "[:lower:]")")
       [[ -n "$otp_period" ]] && cmd+=(--time-step-size="$otp_period"s)
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
-      cmd+=("$otp_secret")
+      cmd+=("-")
       ;;
 
     hotp)
       local counter=$((otp_counter+1))
       cmd=("$OATH" --base32 --hotp --counter="$counter")
       [[ -n "$otp_digits" ]] && cmd+=(--digits="$otp_digits")
-      cmd+=("$otp_secret")
+      cmd+=("-")
       ;;
 
     *)
@@ -382,7 +382,7 @@ cmd_otp_code() {
       ;;
   esac
 
-  local out; out=$("${cmd[@]}") || die "$path: failed to generate OTP code."
+  local out; out=$("${cmd[@]}" <<< "${otp_secret}") || die "$path: failed to generate OTP code."
 
   if [[ "$otp_type" == "hotp" ]]; then
     # Increment HOTP counter in-place


### PR DESCRIPTION
Fixes #224, and drops support for otptool, which only accepts passing secrets as a command line argument. That is often less secure because the command line might be visible to other processes.