### PR TITLE
Convert user-specified TOTP secret to uppercase and remove spaces

### DIFF
--- a/otp.bash
+++ b/otp.bash
@@ -131,6 +131,7 @@ otp_read_secret() {
       read -r secret
   fi
 
+  secret="$(echo "${secret}"|tr "[:lower:]" "[:upper:]"|tr -d ' ')"
   uri="otpauth://totp/${issuer}${separator}${accountname}?secret=${secret}"
   [ -n "$issuer" ] && uri="${uri}&issuer=${issuer}"
   otp_parse_uri "$uri"

--- a/test/append.t
+++ b/test/append.t
@@ -70,6 +70,28 @@ EOD
   [[ $("$PASS" otp uri passfile) == "$uri" ]]
 '
 
+test_expect_success 'Insert secret containing lowercase letters and spaces' '
+  existing="foo bar baz"
+  secret="jbsw y3dp ehpk 3pxp"
+  uri="otpauth://totp/Example:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" insert -e passfile <<< "$existing" &&
+  {
+    expect <<EOD
+      spawn "$PASS" otp append -s -i Example -a alice@google.com -e passfile
+      expect {
+        "Enter" {
+          send "$secret\r"
+          exp_continue
+        }
+        eof
+      }
+EOD
+  } &&
+  [[ $("$PASS" otp uri passfile) == "$uri" ]]
+'
+
 test_expect_success 'Prompts before overwriting key URI' '
   existing="foo bar baz"
   uri1="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Foo"

--- a/test/insert.t
+++ b/test/insert.t
@@ -121,6 +121,15 @@ test_expect_success 'Insert passfile from secret with options(issuer, accountnam
    echo [[ $("$PASS" show passfile) == "$uri" ]]
 '
 
+test_expect_success 'Insert secret containing lowercase letters and spaces' '
+  secret="jbsw y3dp ehpk 3pxp"
+  uri="otpauth://totp/Example:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+  test_pass_init &&
+  "$PASS" otp insert -s -i Example -a alice@google.com passfile <<< "$secret" &&
+   echo [[ $("$PASS" show passfile) == "$uri" ]]
+'
+
 test_expect_success 'Insert from secret without passfile' '
   secret="JBSWY3DPEHPK3PXP"
   uri="otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"


### PR DESCRIPTION
When adding TOTP authentication to one's Dropbox account, the webpage shows the TOTP secret in groups of 4 lowercase letters separated by spaces.

Trying to copy this secret into `pass otp append` will insert the TOTP secret literally as copied, which leads to incorrect TOTP codes being generated.

Change the pass-otp behavior such that secrets are automatically converted to uppercase and have any spaces removed.